### PR TITLE
2 pdf exports

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "module": "streamlit",
             "args": [
                 "run",
-                "home.py"
+                "01_home.py"
             ],
             "justMyCode": false
         },

--- a/01_home.py
+++ b/01_home.py
@@ -11,6 +11,33 @@ st.set_page_config(
 )    
 st.session_state.update(st.session_state)
 ip = Image.open("assets/images/HomeImage.jpg")
+
+st.markdown("""
+    <style>
+        @media print {
+            /* Hide the Streamlit menu and other elements you don't want to print */
+            [data-testid="stSidebar"] {
+                display: none !important;
+            }
+
+            .main {
+                max-width: 8in !important;
+            }
+
+            span, p, div, textarea, input {
+                color: #000 !important;
+            }
+            
+            .stMarkdown, .stCodeBlock, [data-testid="caption"], [data-testid="stMarkdownContainer"], [data-testid="stImage"], [data-baseweb="textarea"] {
+                max-width: 8in !important;
+                word-break: break-all;
+            }
+
+        }
+    </style>
+""", unsafe_allow_html=True)
+
+
 st.header("6 Steps to Better Project Planning and Controlling")
 st.markdown("---")
 st.write("Fill in the project plan with Askme assistance, use NLP for sentiment and engagement analysis of communication channels and reports, use target activity plan analysis report for analysis of tasks and activities and finally a comprehensive list of possible risks classified by phase and probability set by triggers will speed up issue identification.")

--- a/pages/10_plan.py
+++ b/pages/10_plan.py
@@ -77,6 +77,30 @@ st.set_page_config(
       layout="wide",
       initial_sidebar_state="collapsed",
 )
+st.markdown("""
+    <style>
+        @media print {
+            /* Hide the Streamlit menu and other elements you don't want to print */
+            [data-testid="stSidebar"] {
+                display: none !important;
+            }
+
+            .main {
+                max-width: 8in !important;
+            }
+
+            span, p, div, textarea, input {
+                color: #000 !important;
+            }
+            
+            .stMarkdown, .stCodeBlock, [data-testid="caption"], [data-testid="stMarkdownContainer"], [data-testid="stImage"], [data-baseweb="textarea"] {
+                max-width: 8in !important;
+                word-break: break-all;
+            }
+
+        }
+    </style>
+""", unsafe_allow_html=True)
 
 st.markdown("<h3 style='text-align: center; color: white; background: grey;'>The PM Monitor</h3>", unsafe_allow_html=True)
 

--- a/pages/12_save_plan.py
+++ b/pages/12_save_plan.py
@@ -72,7 +72,30 @@ st.set_page_config(
       layout="wide",
       initial_sidebar_state="collapsed",
 )
+st.markdown("""
+    <style>
+        @media print {
+            /* Hide the Streamlit menu and other elements you don't want to print */
+            [data-testid="stSidebar"] {
+                display: none !important;
+            }
 
+            .main {
+                max-width: 8in !important;
+            }
+
+            span, p, div, textarea, input {
+                color: #000 !important;
+            }
+            
+            .stMarkdown, .stCodeBlock, [data-testid="caption"], [data-testid="stMarkdownContainer"], [data-testid="stImage"], [data-baseweb="textarea"] {
+                max-width: 8in !important;
+                word-break: break-all;
+            }
+
+        }
+    </style>
+""", unsafe_allow_html=True)
 st.markdown("<h3 style='text-align: center; color: white; background: grey;'>The PM Monitor</h3>", unsafe_allow_html=True)
 
 

--- a/pages/31_charter.py
+++ b/pages/31_charter.py
@@ -12,7 +12,30 @@ st.set_page_config(
       layout="wide",
       initial_sidebar_state="collapsed",
 )
+st.markdown("""
+    <style>
+        @media print {
+            /* Hide the Streamlit menu and other elements you don't want to print */
+            [data-testid="stSidebar"] {
+                display: none !important;
+            }
 
+            .main {
+                max-width: 8in !important;
+            }
+
+            span, p, div, textarea, input {
+                color: #000 !important;
+            }
+            
+            .stMarkdown, .stCodeBlock, [data-testid="caption"], [data-testid="stMarkdownContainer"], [data-testid="stImage"], [data-baseweb="textarea"] {
+                max-width: 8in !important;
+                word-break: break-all;
+            }
+
+        }
+    </style>
+""", unsafe_allow_html=True)
 if 'thepmheader' not in st.session_state:
  st.warning("Sorry, plan is missing.  Please enter or import a plan")
  st.stop()

--- a/pages/32_canvas.py
+++ b/pages/32_canvas.py
@@ -117,7 +117,30 @@ def render_svg(svg):
 
 # set_bg_hack('background.png')
 # initialize session state variables
+st.markdown("""
+    <style>
+        @media print {
+            /* Hide the Streamlit menu and other elements you don't want to print */
+            [data-testid="stSidebar"] {
+                display: none !important;
+            }
 
+            .main {
+                max-width: 8in !important;
+            }
+
+            span, p, div, textarea, input {
+                color: #000 !important;
+            }
+            
+            .stMarkdown, .stCodeBlock, [data-testid="caption"], [data-testid="stMarkdownContainer"], [data-testid="stImage"], [data-baseweb="textarea"] {
+                max-width: 8in !important;
+                word-break: break-all;
+            }
+
+        }
+    </style>
+""", unsafe_allow_html=True)
 mygrid = make_grid(5,5)
 
 if 'thepmheader' not in st.session_state:

--- a/pages/33_stoplight.py
+++ b/pages/33_stoplight.py
@@ -17,7 +17,30 @@ from wordcloud import WordCloud, STOPWORDS
 import matplotlib.pyplot as plt
 
 st.session_state.update(st.session_state)
+st.markdown("""
+    <style>
+        @media print {
+            /* Hide the Streamlit menu and other elements you don't want to print */
+            [data-testid="stSidebar"] {
+                display: none !important;
+            }
 
+            .main {
+                max-width: 8in !important;
+            }
+
+            span, p, div, textarea, input {
+                color: #000 !important;
+            }
+            
+            .stMarkdown, .stCodeBlock, [data-testid="caption"], [data-testid="stMarkdownContainer"], [data-testid="stImage"], [data-baseweb="textarea"] {
+                max-width: 8in !important;
+                word-break: break-all;
+            }
+
+        }
+    </style>
+""", unsafe_allow_html=True)
 im = Image.open("assets/images/BlueZoneIT.ico")
 st.set_page_config(
       page_title="The PM Monitor Stoplight Report",

--- a/pages/50_about.py
+++ b/pages/50_about.py
@@ -8,7 +8,30 @@ st.set_page_config(
       layout="wide",
       initial_sidebar_state="collapsed",
 )
+st.markdown("""
+    <style>
+        @media print {
+            /* Hide the Streamlit menu and other elements you don't want to print */
+            [data-testid="stSidebar"] {
+                display: none !important;
+            }
 
+            .main {
+                max-width: 8in !important;
+            }
+
+            span, p, div, textarea, input {
+                color: #000 !important;
+            }
+            
+            .stMarkdown, .stCodeBlock, [data-testid="caption"], [data-testid="stMarkdownContainer"], [data-testid="stImage"], [data-baseweb="textarea"] {
+                max-width: 8in !important;
+                word-break: break-all;
+            }
+
+        }
+    </style>
+""", unsafe_allow_html=True)
 st.markdown("### About")
 
 st.subheader("Services")

--- a/pages/60_communication.py
+++ b/pages/60_communication.py
@@ -19,7 +19,30 @@ st.set_page_config(
       layout="wide",
       initial_sidebar_state="collapsed",
 )
+st.markdown("""
+    <style>
+        @media print {
+            /* Hide the Streamlit menu and other elements you don't want to print */
+            [data-testid="stSidebar"] {
+                display: none !important;
+            }
 
+            .main {
+                max-width: 8in !important;
+            }
+
+            span, p, div, textarea, input {
+                color: #000 !important;
+            }
+            
+            .stMarkdown, .stCodeBlock, [data-testid="caption"], [data-testid="stMarkdownContainer"], [data-testid="stImage"], [data-baseweb="textarea"] {
+                max-width: 8in !important;
+                word-break: break-all;
+            }
+
+        }
+    </style>
+""", unsafe_allow_html=True)
 reporttitle("Team Communication Analysis", st.session_state['thepmheader'])
 
 st.write("Using your team communication channel messages, analysis of the sentiment, word density (what they are talking about") 

--- a/pages/70_risk.py
+++ b/pages/70_risk.py
@@ -19,7 +19,30 @@ engagementscoreuser = 0
 sentimenttscoreuser = 0
 
 st.session_state.update(st.session_state)
+st.markdown("""
+    <style>
+        @media print {
+            /* Hide the Streamlit menu and other elements you don't want to print */
+            [data-testid="stSidebar"] {
+                display: none !important;
+            }
 
+            .main {
+                max-width: 8in !important;
+            }
+
+            span, p, div, textarea, input {
+                color: #000 !important;
+            }
+            
+            .stMarkdown, .stCodeBlock, [data-testid="caption"], [data-testid="stMarkdownContainer"], [data-testid="stImage"], [data-baseweb="textarea"] {
+                max-width: 8in !important;
+                word-break: break-all;
+            }
+
+        }
+    </style>
+""", unsafe_allow_html=True)
 im = Image.open("assets/images/BlueZoneIT.ico")
 st.set_page_config(
       page_title="The PM Monitor Risks",

--- a/pages/80_wbs.py
+++ b/pages/80_wbs.py
@@ -94,7 +94,30 @@ def find_paths(graph, node, slackTimes, paths):
 
 # https://github.com/sanatsingh/Critical-Path-Method-SE/blob/master/ca_2.py
 # https://levelup.gitconnected.com/how-to-create-a-multi-layer-gantt-chart-using-plotly-e7d7f158938c
+st.markdown("""
+    <style>
+        @media print {
+            /* Hide the Streamlit menu and other elements you don't want to print */
+            [data-testid="stSidebar"] {
+                display: none !important;
+            }
 
+            .main {
+                max-width: 8in !important;
+            }
+
+            span, p, div, textarea, input {
+                color: #000 !important;
+            }
+            
+            .stMarkdown, .stCodeBlock, [data-testid="caption"], [data-testid="stMarkdownContainer"], [data-testid="stImage"], [data-baseweb="textarea"] {
+                max-width: 8in !important;
+                word-break: break-all;
+            }
+
+        }
+    </style>
+""", unsafe_allow_html=True)
 im = Image.open("assets/images/BlueZoneIT.ico")
 st.set_page_config(
       page_title="The PM Monitor Work Breakdown Activities",


### PR DESCRIPTION
Janet I found this way to use css in an st.markdown block that activates on a browser or streamlit app print. There are probably still elements that have to be modified but as I go through the app I'll find and add css for them. This covers most of it. It makes all the printed text black and it maxs width of element to 8 inches 

```
st.markdown("""
    <style>
        @media print {
            /* Hide the Streamlit menu and other elements you don't want to print */
            [data-testid="stSidebar"] {
                display: none !important;
            }

            .main {
                max-width: 8in !important;
            }

            span, p, div, textarea, input {
                color: #000 !important;
            }
            
            .stMarkdown, .stCodeBlock, [data-testid="caption"], [data-testid="stMarkdownContainer"], [data-testid="stImage"], [data-baseweb="textarea"] {
                max-width: 8in !important;
                word-break: break-all;
            }

        }
    </style>
""", unsafe_allow_html=True)
```

